### PR TITLE
Show all subpages in the TOC

### DIFF
--- a/src/TableOfContentsPreview.tsx
+++ b/src/TableOfContentsPreview.tsx
@@ -48,6 +48,8 @@ export const TableOfContentsPreview: React.FC<TableOfContentsPreviewProps> = (pr
         divClass += ' toc-h3';
       } else if (hasSubs) {
         divClass += ' toc-text toc-subs';
+      } else {
+        divClass += ' toc-text';
       }
       tocPreview.push(
         <div className={divClass} key={item.id} onClick={(e) => handleClick(item)}>

--- a/src/TableOfContentsSettings.tsx
+++ b/src/TableOfContentsSettings.tsx
@@ -4,14 +4,15 @@ import { TOCSettings } from './types';
 type TableOfContentsSettingsProps = {
   isDarkMode: boolean,
   tocSettings: TOCSettings,
-  onToggleIncludeSubblocks: (event: React.ChangeEvent<HTMLInputElement>) => void,
-  onToggleAddDeeplinks: (event: React.ChangeEvent<HTMLInputElement>) => void,
-  onToggleIncludeSubtitles: (event: React.ChangeEvent<HTMLInputElement>) => void,
-  onToggleIncludeHeadings: (event: React.ChangeEvent<HTMLInputElement>) => void,
+  onToggleSettingsCheckbox:(event: React.ChangeEvent<HTMLInputElement>, setting: keyof TOCSettings) => void,
 }
 
 export const TableOfContentsSettings: React.FC<TableOfContentsSettingsProps> = (props) => {
-  const { isDarkMode, tocSettings, onToggleIncludeSubblocks, onToggleAddDeeplinks, onToggleIncludeSubtitles, onToggleIncludeHeadings } = props;
+  const {
+    isDarkMode,
+    tocSettings,
+    onToggleSettingsCheckbox,
+  } = props;
   
   return (
     <div className={`toc-settings ${isDarkMode ? 'dark' : 'light'}`}>
@@ -23,29 +24,47 @@ export const TableOfContentsSettings: React.FC<TableOfContentsSettingsProps> = (
               name="addDeeplinks"
               type="checkbox"
               checked={tocSettings.addDeeplinks}
-              onChange={onToggleAddDeeplinks}
+              onChange={(e) => onToggleSettingsCheckbox(e, 'addDeeplinks')}
             />
             <span>Add deeplinks</span>
           </label>
         </div>
-        <div className="settingsItem">
+        {/* Subpage settings */}
+        <div className={`settingsItem ${tocSettings.showSubpages ? 'hasSubItems' : ''} ${isDarkMode ? 'dark' : ''}`}>
           <label>
             <input
-              name="includeSubblocks"
+              name="showSubpages"
               type="checkbox"
-              checked={tocSettings.includeSubblocks}
-              onChange={onToggleIncludeSubblocks}
+              checked={tocSettings.showSubpages}
+              onChange={(e) => onToggleSettingsCheckbox(e, 'showSubpages')}
             />
-            <span>Include subblocks</span>
+            <span>Show subpages</span>
           </label>
+
+          { 
+            tocSettings.showSubpages &&
+            <div className="settingsSubItem">
+              <label>
+                <input
+                  name="showOnlyStyledSubpages"
+                  type="checkbox"
+                  checked={tocSettings.showOnlyStyledSubpages}
+                  onChange={(e) => onToggleSettingsCheckbox(e, 'showOnlyStyledSubpages')}
+                />
+                <span>Only styled subpages</span>
+              </label>
+          </div>
+          }
         </div>
+
+        {/* Styling settings */}
         <div className="settingsItem">
           <label>
             <input
               name="includeSubtitle"
               type="checkbox"
               checked={tocSettings.includeSubtitles}
-              onChange={onToggleIncludeSubtitles}
+              onChange={(e) => onToggleSettingsCheckbox(e, 'includeSubtitles')}
             />
             <span>Include subtitles</span>
           </label>
@@ -56,7 +75,7 @@ export const TableOfContentsSettings: React.FC<TableOfContentsSettingsProps> = (
               name="includeHeadings"
               type="checkbox"
               checked={tocSettings.includeHeadings}
-              onChange={onToggleIncludeHeadings}
+              onChange={(e) => onToggleSettingsCheckbox(e, 'includeHeadings')}
             />
             <span>Include headings</span>
           </label>

--- a/src/TableOfContentsSettings.tsx
+++ b/src/TableOfContentsSettings.tsx
@@ -30,7 +30,7 @@ export const TableOfContentsSettings: React.FC<TableOfContentsSettingsProps> = (
           </label>
         </div>
         {/* Subpage settings */}
-        <div className={`settingsItem ${tocSettings.showSubpages ? 'hasSubItems' : ''} ${isDarkMode ? 'dark' : ''}`}>
+        <div className={`settingsItem ${isDarkMode ? 'dark' : ''}`}>
           <label>
             <input
               name="showSubpages"
@@ -40,21 +40,6 @@ export const TableOfContentsSettings: React.FC<TableOfContentsSettingsProps> = (
             />
             <span>Show subpages</span>
           </label>
-
-          { 
-            tocSettings.showSubpages &&
-            <div className="settingsSubItem">
-              <label>
-                <input
-                  name="showOnlyStyledSubpages"
-                  type="checkbox"
-                  checked={tocSettings.showOnlyStyledSubpages}
-                  onChange={(e) => onToggleSettingsCheckbox(e, 'showOnlyStyledSubpages')}
-                />
-                <span>Only styled subpages</span>
-              </label>
-          </div>
-          }
         </div>
 
         {/* Styling settings */}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,7 +32,6 @@ const App: React.FC<{}> = () => {
   // TOC content
   const [tocSettings, setTocSettings] = React.useState<TOCSettings>({
     showSubpages: true,
-    showOnlyStyledSubpages: false,
     addDeeplinks: true,
     includeSubtitles: true,
     includeHeadings: true,
@@ -188,7 +187,6 @@ const App: React.FC<{}> = () => {
       tocItemCount: getTOCItemCount(tableOfContentsItems).toString(),
       tocDeepness: getTOCDeepness(tableOfContentsItems).toString(),
       settingsShowSubpages: tocSettings.showSubpages.toString(),
-      settingsShowOnlyStyledSubpages: tocSettings.showOnlyStyledSubpages.toString(),      
       settingsAddDeeplinks: tocSettings.addDeeplinks.toString(),
       settingsIncludeSubtitles: tocSettings.includeSubtitles.toString(),
       settingsIncludeHeadings: tocSettings.includeHeadings.toString(),

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -30,7 +30,8 @@ const App: React.FC<{}> = () => {
 
   // TOC content
   const [tocSettings, setTocSettings] = React.useState<TOCSettings>({
-    includeSubblocks: true,
+    showSubpages: true,
+    showOnlyStyledSubpages: false,
     addDeeplinks: true,
     includeSubtitles: true,
     includeHeadings: true,
@@ -38,32 +39,12 @@ const App: React.FC<{}> = () => {
   const [tableOfContentsItems, setTableOfContentsItems] = React.useState<CraftTextBlock[]>([]);
   const [currentPageId, setCurrentPageId] = React.useState<string | null>(null);
 
-  function onToggleIncludeSubblocks(event: React.ChangeEvent<HTMLInputElement>) {
-    setTocSettings({
+  function onToggleSettingsCheckbox(event: React.ChangeEvent<HTMLInputElement>, setting: keyof TOCSettings) {
+    const newSettings = {
       ...tocSettings,
-      includeSubblocks: event.target.checked
-    });
-  }
-
-  function onToggleAddDeeplinks(event: React.ChangeEvent<HTMLInputElement>) {
-    setTocSettings({
-      ...tocSettings,
-      addDeeplinks: event.target.checked
-    });
-  }
-
-  function onToggleIncludeSubtitles(event: React.ChangeEvent<HTMLInputElement>) {
-    setTocSettings({
-      ...tocSettings,
-      includeSubtitles: event.target.checked
-    });
-  }
-
-  function onToggleIncludeHeadings(event: React.ChangeEvent<HTMLInputElement>) {
-    setTocSettings({
-      ...tocSettings,
-      includeHeadings: event.target.checked
-    });
+      [setting]: event.target.checked,
+    };
+    setTocSettings(newSettings);
   }
 
   function reloadTOC() {
@@ -130,7 +111,8 @@ const App: React.FC<{}> = () => {
           rootTocItemCount: tableOfContentsItems.length.toString(),
           tocItemCount: getTOCItemCount(tableOfContentsItems).toString(),
           tocDeepness: getTOCDeepness(tableOfContentsItems).toString(),
-          settingsIncludeSubblocks: tocSettings.includeSubblocks.toString(),
+          settingsShowSubpages: tocSettings.showSubpages.toString(),
+          settingsShowOnlyStyledSubpages: tocSettings.showOnlyStyledSubpages.toString(),
           settingsAddDeeplinks: tocSettings.addDeeplinks.toString(),
           settingsIncludeSubtitles: tocSettings.includeSubtitles.toString(),
           settingsIncludeHeadings: tocSettings.includeHeadings.toString(),
@@ -208,10 +190,7 @@ const App: React.FC<{}> = () => {
               <TableOfContentsSettings
                 isDarkMode={isDarkMode}
                 tocSettings={tocSettings}
-                onToggleIncludeSubblocks={onToggleIncludeSubblocks}
-                onToggleAddDeeplinks={onToggleAddDeeplinks}
-                onToggleIncludeSubtitles={onToggleIncludeSubtitles}
-                onToggleIncludeHeadings={onToggleIncludeHeadings}
+                onToggleSettingsCheckbox={onToggleSettingsCheckbox}
               />
 
               {

--- a/src/craftdata.ts
+++ b/src/craftdata.ts
@@ -15,11 +15,18 @@ function filterTextBlockForTableOfContent(block: CraftTextBlock, tocSettings: TO
 
   const textSubBlocks = block.subblocks.filter(isTextBlock);
   textSubBlocks.forEach(textSubBlock => {
-    if (tocSettings.includeSubblocks && doesTextBlockContainTitleSubblock(textSubBlock, tocSettings)) {
+    const containTitleSubblock = doesTextBlockContainTitleSubblock(textSubBlock, tocSettings)
+    if (tocSettings.showSubpages && tocSettings.showOnlyStyledSubpages && containTitleSubblock) {
+      // Add only styled textblock to TOC
+      console.log(`A - showSubpages=${tocSettings.showSubpages} - showOnlyStyledSubpages=${tocSettings.showOnlyStyledSubpages} - containTitleSubblock=${containTitleSubblock}`)
       filteredTextBlock.subblocks.push(filterTextBlockForTableOfContent(textSubBlock, tocSettings));
+    } else if (tocSettings.showSubpages) {
+      // Add any textblock to TOC
+      console.log(`B - showSubpages=${tocSettings.showSubpages} - showOnlyStyledSubpages=${tocSettings.showOnlyStyledSubpages} - containTitleSubblock=${containTitleSubblock}`)
+      filteredTextBlock.subblocks.push(textSubBlock);
     } else if (isTitleTextBlock(textSubBlock, tocSettings)) {
       // Othersiwe add only title textblock
-      if (tocSettings.includeSubblocks) {
+      if (tocSettings.showSubpages) {
         filteredTextBlock.subblocks.push(textSubBlock);
       } else {
         const filteredTextSublockWithoutSubsubblocks = JSON.parse(JSON.stringify(textSubBlock));

--- a/src/style.css
+++ b/src/style.css
@@ -2,10 +2,16 @@ body {
   background-color: white;
   font-family: 'Roboto', sans-serif;
   margin: 0px;
+
+  --color-lightgrey: #f3f3f3;
+  --color-almostblack: #222222;
+
+  --color-black01: rgba(255, 255, 255, 0.1);
+  --color-white01: rgba(0, 0, 0, 0.1);
 }
 
 body.dark {
-  background-color: #222222;
+  background-color: var(--color-almostblack);
   color: white;
 }
 
@@ -25,12 +31,12 @@ header {
 
 .header-dark {
   border-bottom: 0.5px solid rgba(255, 255, 255, 0.4);
-  background-color: #222222;
+  background-color: var(--color-almostblack);
 }
 
 .header-light {
   border-bottom: 0.5px solid rgba(0, 0, 0, 0.2);
-  background-color: #f3f3f3;
+  background-color: var(--color-lightgrey);
 }
 
 header .title {
@@ -58,7 +64,22 @@ main {
   margin: 2px 0px;
 }
 
-.toc-settings .settings .settingsItem label {
+.toc-settings .settings .settingsItem.hasSubItems {
+  background-color: var(--color-white01);
+  border-radius: 4px;
+}
+
+.toc-settings .settings .settingsItem.hasSubItems.dark {
+  background-color: var(--color-black01);
+}
+
+.toc-settings .settings .settingsSubItem {
+  font-size: 11px;
+  width: 100%;
+  margin-left: 4px;
+}
+
+.toc-settings .settings .settingsItem label, .toc-settings .settings .settingsSubItem label {
   display: flex;
   align-items: center;
   width: 100%;
@@ -230,12 +251,12 @@ footer {
 
 .footer-dark {
   border-top: 0.5px solid rgba(255, 255, 255, 0.4);
-  background-color: #222222;
+  background-color: var(--color-almostblack);
 }
 
 .footer-light {
   border-top: 0.5px solid rgba(0, 0, 0, 0.2);
-  background-color: #f3f3f3;
+  background-color: var(--color-lightgrey);
 }
 
 .authorlink-dark {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,12 @@
 export type TOCSettings = {
-  includeSubblocks: boolean;
+  // Subpages options
+  showSubpages: boolean;
+  showOnlyStyledSubpages: boolean;
+
+  // Deeplink options
   addDeeplinks: boolean;
+
+  // Style options
   includeSubtitles: boolean;
   includeHeadings: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,7 @@ import { DevicePlatform } from '@craftdocs/craft-extension-api';
 export type TOCSettings = {
   // Subpages options
   showSubpages: boolean;
-  showOnlyStyledSubpages: boolean;
-
+  
   // Deeplink options
   addDeeplinks: boolean;
 


### PR DESCRIPTION
Previously only those subpages were added to the TOC, which were styled (title, subtitle or heading) or contained any styled text block. With this change all the subpages are added to the TOC.